### PR TITLE
Productionビルドがおかしくなる不具合の回避

### DIFF
--- a/src/store/modules/skillDetail/index.ts
+++ b/src/store/modules/skillDetail/index.ts
@@ -1,3 +1,7 @@
+// Workaround for parcel's JSPackager bug.
+// TODO: Remove when https://github.com/parcel-bundler/parcel/pull/1011 is merged
+const moduleName = '~/store/modules/skillDetail'
+
 export { default } from './reducer'
 
 export * from './actions'


### PR DESCRIPTION
Parcelのバグで同一内容のファイルがある場合、片方がもう片方と同じとみなされてしまうので違うファイルと認識させるようにした